### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
 	<packaging>pom</packaging>
 	<name>Spring Boot R2DBC</name>
 	<description>Spring Boot R2DBCe</description>
-	<url>http://projects.spring.io/spring-boot/</url>
+	<url>https://projects.spring.io/spring-boot/</url>
 
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<properties>

--- a/spring-boot-actuator-autoconfigure-r2dbc/pom.xml
+++ b/spring-boot-actuator-autoconfigure-r2dbc/pom.xml
@@ -12,10 +12,10 @@
 	<artifactId>spring-boot-actuator-autoconfigure-r2dbc</artifactId>
 	<name>Spring Boot R2DBC Actuator AutoConfigure</name>
 	<description>Spring Boot R2DBC Actuator AutoConfigure</description>
-	<url>http://projects.spring.io/spring-boot/</url>
+	<url>https://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<dependencies>
 		<!-- Compile -->

--- a/spring-boot-actuator-r2dbc/pom.xml
+++ b/spring-boot-actuator-r2dbc/pom.xml
@@ -12,10 +12,10 @@
 	<artifactId>spring-boot-actuator-r2dbc</artifactId>
 	<name>Spring Boot R2DBC Actuator</name>
 	<description>Spring Boot R2DBC Actuator</description>
-	<url>http://projects.spring.io/spring-boot/</url>
+	<url>https://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<dependencies>
 		<dependency>

--- a/spring-boot-autoconfigure-r2dbc/pom.xml
+++ b/spring-boot-autoconfigure-r2dbc/pom.xml
@@ -12,10 +12,10 @@
 	<artifactId>spring-boot-autoconfigure-r2dbc</artifactId>
 	<name>Spring Boot R2DBC Auto-Configuration</name>
 	<description>Spring Boot R2DBC Auto-Configuration</description>
-	<url>http://projects.spring.io/spring-boot/</url>
+	<url>https://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 	<dependencies>
 		<dependency>

--- a/spring-boot-dependencies-r2dbc/pom.xml
+++ b/spring-boot-dependencies-r2dbc/pom.xml
@@ -15,10 +15,10 @@
 	<packaging>pom</packaging>
 	<name>Spring Boot R2DBC Dependencies</name>
 	<description>Spring Boot R2DBC Dependency Management</description>
-	<url>http://projects.spring.io/spring-boot/</url>
+	<url>https://projects.spring.io/spring-boot/</url>
 	<organization>
 		<name>Pivotal Software, Inc.</name>
-		<url>http://www.spring.io</url>
+		<url>https://www.spring.io</url>
 	</organization>
 
 	<dependencyManagement>
@@ -104,7 +104,7 @@
 			<repositories>
 				<repository>
 					<id>spring-snapshots</id>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -118,7 +118,7 @@
 				</repository>
 				<repository>
 					<id>spring-milestone</id>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 				</repository>
 			</repositories>
 		</profile>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://projects.spring.io/spring-boot/ migrated to:  
  https://projects.spring.io/spring-boot/ ([https](https://projects.spring.io/spring-boot/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.spring.io migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).
* http://repo.spring.io/milestone migrated to:  
  https://repo.spring.io/milestone ([https](https://repo.spring.io/milestone) result 302).
* http://repo.spring.io/snapshot migrated to:  
  https://repo.spring.io/snapshot ([https](https://repo.spring.io/snapshot) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance