### PR TITLE
bug fix: password assigned to username

### DIFF
--- a/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilder.java
+++ b/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilder.java
@@ -48,7 +48,7 @@ public final class ConnectionFactoryBuilder {
 		}
 		String password = properties.determinePassword();
 		if (StringUtils.hasText(password)) {
-			builder.option(ConnectionFactoryOptions.PASSWORD, username);
+			builder.option(ConnectionFactoryOptions.PASSWORD, password);
 		}
 		String databaseName = properties.determineDatabaseName();
 		if (StringUtils.hasText(databaseName)) {


### PR DESCRIPTION
Fix password assigned to username wrongly in ConnectionFactoryBuilder.java
```
                String password = properties.determinePassword();
		if (StringUtils.hasText(password)) {
			builder.option(ConnectionFactoryOptions.PASSWORD, username);
		}
```