### PR TITLE
Add actuator metrics support for r2dbc-pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<module>spring-boot-starter-r2dbc-h2</module>
 		<module>spring-boot-starter-data-r2dbc</module>
 		<module>spring-boot-example-h2</module>
+		<module>spring-boot-example-r2dbc-actuator</module>
 	</modules>
 
 	<scm>

--- a/spring-boot-actuator-autoconfigure-r2dbc/pom.xml
+++ b/spring-boot-actuator-autoconfigure-r2dbc/pom.xml
@@ -44,6 +44,11 @@
 			<artifactId>r2dbc-spi</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- Annotation processing -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-actuator-autoconfigure-r2dbc/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/ConnectionPoolMetricsAutoConfiguration.java
+++ b/spring-boot-actuator-autoconfigure-r2dbc/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/ConnectionPoolMetricsAutoConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.r2dbc.metrics.pool;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.r2dbc.pool.ConnectionPool;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
+import org.springframework.boot.actuate.r2dbc.metrics.ConnectionPoolMetrics;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Map;
+
+/**
+ * {@link EnableAutoConfiguration Auto-configuration} for metrics on all available
+ * {@link ConnectionPool connection pools}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+@Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter({MetricsAutoConfiguration.class, SimpleMetricsExportAutoConfiguration.class})
+@ConditionalOnClass({ConnectionPool.class, MeterRegistry.class})
+@ConditionalOnBean({ConnectionPool.class, MeterRegistry.class})
+public class ConnectionPoolMetricsAutoConfiguration {
+
+	@Autowired
+	public void bindConnectionPoolsToRegistry(Map<String, ConnectionPool> pools, MeterRegistry registry) {
+		pools.forEach((beanName, pool) -> new ConnectionPoolMetrics(pool, beanName, Tags.empty()).bindTo(registry));
+	}
+
+}

--- a/spring-boot-actuator-autoconfigure-r2dbc/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/package-info.java
+++ b/spring-boot-actuator-autoconfigure-r2dbc/src/main/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Auto-configuration for R2DBC pool metrics.
+ */
+package org.springframework.boot.actuate.autoconfigure.r2dbc.metrics.pool;

--- a/spring-boot-actuator-autoconfigure-r2dbc/src/main/resources/META-INF/spring.factories
+++ b/spring-boot-actuator-autoconfigure-r2dbc/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.boot.actuate.autoconfigure.r2dbc.ConnectionFactoryHealthIndicatorAutoConfiguration
+org.springframework.boot.actuate.autoconfigure.r2dbc.ConnectionFactoryHealthIndicatorAutoConfiguration,\
+org.springframework.boot.actuate.autoconfigure.r2dbc.metrics.pool.ConnectionPoolMetricsAutoConfiguration

--- a/spring-boot-actuator-autoconfigure-r2dbc/src/test/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/ConnectionPoolMetricsAutoConfigurationTests.java
+++ b/spring-boot-actuator-autoconfigure-r2dbc/src/test/java/org/springframework/boot/actuate/autoconfigure/r2dbc/metrics/pool/ConnectionPoolMetricsAutoConfigurationTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.autoconfigure.r2dbc.metrics.pool;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.spi.ConnectionFactory;
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ConnectionPoolMetricsAutoConfiguration}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ConnectionPoolMetricsAutoConfigurationTests {
+
+	private ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ConnectionPoolMetricsAutoConfiguration.class))
+			.withUserConfiguration(TestConfig.class);
+
+	@Test
+	public void shouldBindConnectionPoolToMeterRegistry() {
+		this.contextRunner
+				.run((context) -> {
+					MeterRegistry registry = context.getBean(MeterRegistry.class);
+					assertThat(registry.find("r2dbc.pool.acquired").gauges())
+							.extracting(Meter::getId)
+							.extracting(id -> id.getTag("name"))
+							.containsExactlyInAnyOrder("firstPool", "secondPool");
+				});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestConfig {
+
+		@Bean
+		SimpleMeterRegistry registry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		ConnectionFactory connectionFactory() {
+			return new H2ConnectionFactory(H2ConnectionConfiguration.builder()
+					.inMemory("db-" + new Random().nextInt()).option("DB_CLOSE_DELAY=-1")
+					.build());
+		}
+
+		@Bean
+		ConnectionPool firstPool(ConnectionFactory connectionFactory) {
+			return new ConnectionPool(ConnectionPoolConfiguration.builder(connectionFactory).build());
+		}
+
+		@Bean
+		ConnectionPool secondPool(ConnectionFactory connectionFactory) {
+			return new ConnectionPool(ConnectionPoolConfiguration.builder(connectionFactory).build());
+		}
+
+
+	}
+
+
+}

--- a/spring-boot-actuator-r2dbc/pom.xml
+++ b/spring-boot-actuator-r2dbc/pom.xml
@@ -31,6 +31,16 @@
 			<artifactId>r2dbc-spi</artifactId>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-pool</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+			<optional>true</optional>
+		</dependency>
 		<!-- Annotation processing -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-boot-actuator-r2dbc/src/main/java/org/springframework/boot/actuate/r2dbc/metrics/ConnectionPoolMetrics.java
+++ b/spring-boot-actuator-r2dbc/src/main/java/org/springframework/boot/actuate/r2dbc/metrics/ConnectionPoolMetrics.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.r2dbc.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.PoolMetrics;
+
+/**
+ * A {@link MeterBinder} for a {@link ConnectionPool}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ConnectionPoolMetrics implements MeterBinder {
+
+	private final ConnectionPool pool;
+
+	private final Iterable<Tag> tags;
+
+	public ConnectionPoolMetrics(ConnectionPool pool, String name, Iterable<Tag> tags) {
+		this.pool = pool;
+		this.tags = Tags.concat(tags, "name", name);
+	}
+
+	@Override
+	public void bindTo(MeterRegistry registry) {
+		this.pool.getMetrics().ifPresent(poolMetrics -> {
+
+			Gauge.builder("r2dbc.pool.acquired", poolMetrics, PoolMetrics::acquiredSize)
+					.tags(this.tags)
+					.description("Size of successfully acquired connections which are in active use")
+					.baseUnit("connections")
+					.register(registry);
+
+			Gauge.builder("r2dbc.pool.allocated", poolMetrics, PoolMetrics::allocatedSize)
+					.tags(this.tags)
+					.description("Size of allocated connections in the pool which are in active use or in idle")
+					.baseUnit("connections")
+					.register(registry);
+
+			Gauge.builder("r2dbc.pool.idle", poolMetrics, PoolMetrics::idleSize)
+					.tags(this.tags)
+					.description("Size of idle connections in the pool")
+					.baseUnit("connections")
+					.register(registry);
+
+			Gauge.builder("r2dbc.pool.pending", poolMetrics, PoolMetrics::pendingAcquireSize)
+					.tags(this.tags)
+					.description("Size of pending to acquire connections from underlying connection factory")
+					.baseUnit("connections")
+					.register(registry);
+
+			Gauge.builder("r2dbc.pool.max.allocated", poolMetrics, PoolMetrics::getMaxAllocatedSize)
+					.tags(this.tags)
+					.description("Maximum size of allocated connections that this pool allows")
+					.baseUnit("connections")
+					.register(registry);
+
+			Gauge.builder("r2dbc.pool.max.pending", poolMetrics, PoolMetrics::getMaxPendingAcquireSize)
+					.tags(this.tags)
+					.description("Maximum size of pending state to acquire connections that this pool allows")
+					.baseUnit("connections")
+					.register(registry);
+
+		});
+	}
+}

--- a/spring-boot-actuator-r2dbc/src/main/java/org/springframework/boot/actuate/r2dbc/metrics/package-info.java
+++ b/spring-boot-actuator-r2dbc/src/main/java/org/springframework/boot/actuate/r2dbc/metrics/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Metrics actuator support for R2DBC.
+ */
+
+package org.springframework.boot.actuate.r2dbc.metrics;

--- a/spring-boot-actuator-r2dbc/src/test/java/org/springframework/boot/actuate/r2dbc/metrics/ConnectionPoolMetricsTests.java
+++ b/spring-boot-actuator-r2dbc/src/test/java/org/springframework/boot/actuate/r2dbc/metrics/ConnectionPoolMetricsTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.boot.actuate.r2dbc.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.pool.ConnectionPool;
+import io.r2dbc.pool.ConnectionPoolConfiguration;
+import io.r2dbc.spi.ConnectionFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Tests for {@link ConnectionPoolMetrics}.
+ *
+ * @author Tadaya Tsuyukubo
+ */
+public class ConnectionPoolMetricsTests {
+
+	private ConnectionFactory connectionFactory;
+
+	@Before
+	public void init() {
+		connectionFactory = new H2ConnectionFactory(H2ConnectionConfiguration.builder()
+				.inMemory("db-" + new Random().nextInt()).option("DB_CLOSE_DELAY=-1")
+				.build());
+	}
+
+	@Test
+	public void metrics() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+		ConnectionPool connectionPool = new ConnectionPool(ConnectionPoolConfiguration.builder(this.connectionFactory)
+				.initialSize(3)
+				.maxSize(7)
+				.build());
+
+		Tag fooTag = Tag.of("foo", "FOO");
+		Tag barTag = Tag.of("bar", "BAR");
+
+		ConnectionPoolMetrics metrics = new ConnectionPoolMetrics(connectionPool, "my-pool", Tags.of(fooTag, barTag));
+		metrics.bindTo(registry);
+
+		// acquire two connections
+		connectionPool.create().subscribe();
+		connectionPool.create().subscribe();
+
+		Gauge gauge;
+
+		gauge = registry.get("r2dbc.pool.acquired").gauge();
+		assertThat(gauge.value()).isEqualTo(2);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+
+		gauge = registry.get("r2dbc.pool.allocated").gauge();
+		assertThat(gauge.value()).isEqualTo(3);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+
+		gauge = registry.get("r2dbc.pool.idle").gauge();
+		assertThat(gauge.value()).isEqualTo(1);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+
+		gauge = registry.get("r2dbc.pool.pending").gauge();
+		assertThat(gauge.value()).isEqualTo(0);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+
+		gauge = registry.get("r2dbc.pool.max.allocated").gauge();
+		assertThat(gauge.value()).isEqualTo(7);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+
+		gauge = registry.get("r2dbc.pool.max.pending").gauge();
+		assertThat(gauge.value()).isEqualTo(Integer.MAX_VALUE);
+		assertThat(gauge.getId().getTags()).containsExactlyInAnyOrder(Tag.of("name", "my-pool"), fooTag, barTag);
+	}
+
+}

--- a/spring-boot-example-r2dbc-actuator/README.adoc
+++ b/spring-boot-example-r2dbc-actuator/README.adoc
@@ -1,0 +1,5 @@
+= Spring Boot R2DBC Example with R2DBC actuator
+
+Start the application to run the WebFlux server at http://localhost:8080.
+
+Metrics actuator is available under http://localhost:8080/actuator/metrics.

--- a/spring-boot-example-r2dbc-actuator/pom.xml
+++ b/spring-boot-example-r2dbc-actuator/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.2.0.M3</version>
+		<relativePath /> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>demo-actuator</artifactId>
+	<version>0.1.0.BUILD-SNAPSHOT</version>
+	<name>Spring Boot Example using R2DBC actuator</name>
+	<description>Example project for Spring Boot R2DBC actuator</description>
+
+	<properties>
+		<java.version>1.8</java.version>
+	</properties>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.springframework.boot.experimental</groupId>
+				<artifactId>spring-boot-dependencies-r2dbc</artifactId>
+				<version>0.1.0.BUILD-SNAPSHOT</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot.experimental</groupId>
+			<artifactId>spring-boot-starter-data-r2dbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot.experimental</groupId>
+			<artifactId>spring-boot-starter-r2dbc-h2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot.experimental</groupId>
+			<artifactId>spring-boot-actuator-autoconfigure-r2dbc</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.r2dbc</groupId>
+			<artifactId>r2dbc-pool</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-core</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-deploy-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-libs-snapshot</id>
+			<url>https://repo.spring.io/libs-snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+</project>

--- a/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/ActuatorDemoApplication.java
+++ b/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/ActuatorDemoApplication.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@SpringBootApplication
+@EnableTransactionManagement
+public class ActuatorDemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(ActuatorDemoApplication.class, args);
+	}
+
+}

--- a/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/City.java
+++ b/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/City.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.demo;
+
+import org.springframework.data.annotation.Id;
+
+/**
+ * @author Mark Paluch
+ */
+public class City {
+
+	@Id
+	private Long id;
+
+	private String name;
+
+	private String state;
+
+	private String country;
+
+	private String map;
+
+	protected City() {
+	}
+
+	public City(String name, String country) {
+		this.name = name;
+		this.country = country;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public String getState() {
+		return this.state;
+	}
+
+	public String getCountry() {
+		return this.country;
+	}
+
+	public String getMap() {
+		return this.map;
+	}
+
+	@Override
+	public String toString() {
+		return getName() + "," + getState() + "," + getCountry();
+	}
+
+}

--- a/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/CityController.java
+++ b/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/CityController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.demo;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author Mark Paluch
+ */
+@RestController
+public class CityController {
+
+	private final CityRepository repository;
+
+	public CityController(CityRepository repository) {
+		this.repository = repository;
+	}
+
+	@GetMapping("/")
+	@Transactional
+	public Flux<City> findCities() {
+		return this.repository.findAll();
+	}
+
+	@GetMapping("/{id}")
+	public Mono<City> findCityById(@PathVariable long id) {
+		return this.repository.findById(id);
+	}
+}

--- a/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/CityRepository.java
+++ b/spring-boot-example-r2dbc-actuator/src/main/java/com/example/demo/CityRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2012-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.demo;
+
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+
+/**
+ * Data R2DBC repository for working with {@link City Cities}.
+ *
+ * @author Mark Paluch
+ */
+public interface CityRepository extends ReactiveCrudRepository<City, Long> {
+
+}

--- a/spring-boot-example-r2dbc-actuator/src/main/resources/application.properties
+++ b/spring-boot-example-r2dbc-actuator/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+management.endpoint.health.show-details=always
+management.endpoints.web.exposure.include=health,info,metrics
+spring.r2dbc.url=r2dbc:h2:mem:///testdb
+spring.r2dbc.pool.initial-size=3

--- a/spring-boot-example-r2dbc-actuator/src/main/resources/data.sql
+++ b/spring-boot-example-r2dbc-actuator/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO CITY (ID, NAME, STATE, COUNTRY, MAP) values (2000, 'Washington', 'DC', 'US', 'Google');

--- a/spring-boot-example-r2dbc-actuator/src/main/resources/schema.sql
+++ b/spring-boot-example-r2dbc-actuator/src/main/resources/schema.sql
@@ -1,0 +1,7 @@
+CREATE TABLE CITY (
+  id         INTEGER IDENTITY PRIMARY KEY,
+  name VARCHAR(30),
+  state  VARCHAR(30),
+  country  VARCHAR(30),
+  map  VARCHAR(30)
+);


### PR DESCRIPTION
Add "ConnectionPoolMetrics" meter binder and
"ConnectionPoolMetricsAutoConfiguration".

[resolves #17]