### PR TITLE
Use user/password/database from url

### DIFF
--- a/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilder.java
+++ b/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilder.java
@@ -40,19 +40,27 @@ public final class ConnectionFactoryBuilder {
 
 	public static ConnectionFactoryBuilder create(R2dbcProperties properties) {
 
-		ConnectionFactoryOptions.Builder builder = ConnectionFactoryOptions
-				.parse(properties.determineUrl()).mutate();
-		String username = properties.determineUsername();
-		if (StringUtils.hasText(username)) {
-			builder.option(ConnectionFactoryOptions.USER, username);
+		ConnectionFactoryOptions options = ConnectionFactoryOptions
+				.parse(properties.determineUrl());
+		ConnectionFactoryOptions.Builder builder = options.mutate();
+
+		if (!options.hasOption(ConnectionFactoryOptions.USER)) {
+			String username = properties.determineUsername();
+			if (StringUtils.hasText(username)) {
+				builder.option(ConnectionFactoryOptions.USER, username);
+			}
 		}
-		String password = properties.determinePassword();
-		if (StringUtils.hasText(password)) {
-			builder.option(ConnectionFactoryOptions.PASSWORD, password);
+		if (!options.hasOption(ConnectionFactoryOptions.PASSWORD)) {
+			String password = properties.determinePassword();
+			if (StringUtils.hasText(password)) {
+				builder.option(ConnectionFactoryOptions.PASSWORD, password);
+			}
 		}
-		String databaseName = properties.determineDatabaseName();
-		if (StringUtils.hasText(databaseName)) {
-			builder.option(ConnectionFactoryOptions.DATABASE, databaseName);
+		if (!options.hasOption(ConnectionFactoryOptions.DATABASE)) {
+			String databaseName = properties.determineDatabaseName();
+			if (StringUtils.hasText(databaseName)) {
+				builder.option(ConnectionFactoryOptions.DATABASE, databaseName);
+			}
 		}
 		if (properties.getProperties() != null) {
 			properties.getProperties()

--- a/spring-boot-autoconfigure-r2dbc/src/test/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilderUnitTests.java
+++ b/spring-boot-autoconfigure-r2dbc/src/test/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryBuilderUnitTests.java
@@ -62,4 +62,21 @@ public class ConnectionFactoryBuilderUnitTests {
 		assertThat(options.getRequiredValue(ConnectionFactoryOptions.PASSWORD))
 				.isEqualTo("pass");
 	}
+
+	@Test
+	public void shouldApplyFromUrl() {
+		R2dbcProperties properties = new R2dbcProperties();
+		properties.setUrl("r2dbc:h2://user:pass@local/mydb");
+		ConnectionFactoryOptions options = ConnectionFactoryBuilder.create(properties).getOptions();
+		assertThat(options.getRequiredValue(ConnectionFactoryOptions.DRIVER))
+				.isEqualTo("h2");
+		assertThat(options.getRequiredValue(ConnectionFactoryOptions.HOST))
+				.isEqualTo("local");
+		assertThat(options.getRequiredValue(ConnectionFactoryOptions.USER))
+				.isEqualTo("user");
+		assertThat(options.getRequiredValue(ConnectionFactoryOptions.PASSWORD))
+				.isEqualTo("pass");
+		assertThat(options.getRequiredValue(ConnectionFactoryOptions.DATABASE))
+				.isEqualTo("mydb");
+	}
 }


### PR DESCRIPTION
Do not override user/password/database with default when they are specified in url.