### PR TITLE
auto-created connection pool can now be deactivated

### DIFF
--- a/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryAutoConfiguration.java
+++ b/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/ConnectionFactoryAutoConfiguration.java
@@ -67,7 +67,7 @@ public class ConnectionFactoryAutoConfiguration {
 	}
 
 	@Configuration
-	@Conditional(UnpooledConnectionUrlCondition.class)
+	@Conditional({UnpooledConnectionUrlCondition.class, ConnectionPoolEnabledCondition.class})
 	@ConditionalOnClass(ConnectionPool.class)
 	@ConditionalOnMissingBean(ConnectionFactory.class)
 	@Import(ConnectionFactoryConfiguration.ConnectionPoolConnectionFactoryConfiguration.class)
@@ -193,6 +193,25 @@ public class ConnectionFactoryAutoConfiguration {
 				return ConditionOutcome.match("R2DBC Connection URL contains pooling configuration");
 			}
 			return ConditionOutcome.noMatch("R2DBC Connection URL does not contain pooling configuration");
+		}
+
+	}
+
+	/**
+	 * {@link Condition} to test if the connection pool is enabled by {@code spring.r2dbc.pool.enabled}
+	 */
+	static class ConnectionPoolEnabledCondition extends SpringBootCondition {
+
+		@Override
+		public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+			Boolean isEnabled = context.getEnvironment().getProperty("spring.r2dbc.pool.enabled", Boolean.class);
+			if (isEnabled == null) {
+				return ConditionOutcome.match("R2DBC Connection pooling flag is not set in the configuration, so TRUE is assumed");
+			}
+			if (isEnabled) {
+				return ConditionOutcome.match("R2DBC Connection pooling is enabled by configuration");
+			}
+			return ConditionOutcome.noMatch("R2DBC Connection pooling is disabled by configuration");
 		}
 
 	}

--- a/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
+++ b/spring-boot-autoconfigure-r2dbc/src/main/java/org/springframework/boot/autoconfigure/r2dbc/R2dbcProperties.java
@@ -403,6 +403,11 @@ public class R2dbcProperties implements BeanClassLoaderAware, InitializingBean {
 	public static class Pool {
 
 		/**
+		 * Is pooling enabled?
+		 */
+		private boolean enabled = true;
+
+		/**
 		 * Idle timeout.
 		 */
 		private Duration maxIdleTime = Duration.ofMinutes(30);
@@ -421,6 +426,14 @@ public class R2dbcProperties implements BeanClassLoaderAware, InitializingBean {
 		 * Validation query.
 		 */
 		private String validationQuery;
+
+		public boolean getEnabled() {
+			return this.enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
 
 		public Duration getMaxIdleTime() {
 			return this.maxIdleTime;


### PR DESCRIPTION
via spring.r2dbc.pool.enabled=false configuration parameter